### PR TITLE
fix: enforce account ownership on avatar and banner update endpoints

### DIFF
--- a/src/BoltonCup.WebAPI/Controllers/AccountsController.cs
+++ b/src/BoltonCup.WebAPI/Controllers/AccountsController.cs
@@ -70,10 +70,12 @@ public class AccountsController(
     [HttpPut("{id:int}/avatar")]
     public async Task<ActionResult> UpdateAvatar(int id, string tempKey)
     {
+        if (id != User.GetAccountId())
+            return Forbid();
         await _accountService.UpdateAvatarAsync(id, tempKey);
         return Ok();
     }
-    
+
     /// <remarks>
     /// Updates an account's banner by accepting a pre-signed S3 key.
     /// The client is responsible for uploading the image to S3 before calling this endpoint.
@@ -82,6 +84,8 @@ public class AccountsController(
     [HttpPut("{id:int}/banner")]
     public async Task<ActionResult> UpdateBanner(int id, string tempKey)
     {
+        if (id != User.GetAccountId())
+            return Forbid();
         await _accountService.UpdateBannerAsync(id, tempKey);
         return Ok();
     }


### PR DESCRIPTION
Any authenticated user could update another user's avatar or banner by passing a different account ID. Now returns 403 if the caller does not own the account.